### PR TITLE
Update protos and add a function for loading creds directly

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -24,7 +24,7 @@ pub(crate) enum InternalConnectError {
         error: std::io::Error,
     },
     ParseCert {
-        file: PathBuf,
+        file: Option<PathBuf>,
         error: std::io::Error,
     },
     InvalidAddress {
@@ -39,7 +39,10 @@ impl fmt::Display for ConnectError {
 
         match &self.internal {
             ReadFile { file, .. } => write!(f, "failed to read file {}", file.display()),
-            ParseCert { file, .. } => write!(f, "failed to parse certificate {}", file.display()),
+            ParseCert { file, .. } => match file {
+                Some(file) => write!(f, "failed to parse certificate {}", file.display()),
+                None => write!(f, "failed to parse certificate"),
+            },
             InvalidAddress { address, .. } => write!(f, "invalid address {}", address),
         }
     }

--- a/vendor/lightning.proto
+++ b/vendor/lightning.proto
@@ -101,8 +101,10 @@ service Lightning {
     rpc SignMessage (SignMessageRequest) returns (SignMessageResponse);
 
     /* lncli: `verifymessage`
-    VerifyMessage verifies a signature over a msg. The signature must be
-    zbase32 encoded and signed by an active node in the resident node's
+    VerifyMessage verifies a signature over a message and recovers the signer's
+    public key. The signature is only deemed valid if the recovered public key
+    corresponds to a node key in the public Lightning network. The signature
+    must be zbase32 encoded and signed by an active node in the resident node's
     channel database. In addition to returning the validity of the signature,
     VerifyMessage also returns the recovered pubkey from the signature.
     */
@@ -140,6 +142,13 @@ service Lightning {
     concerning the number of open+pending channels.
     */
     rpc GetInfo (GetInfoRequest) returns (GetInfoResponse);
+
+    /* lncli: 'getdebuginfo'
+    GetDebugInfo returns debug information concerning the state of the daemon
+    and its subsystems. This includes the full configuration and the latest log
+    entries from the log file.
+    */
+    rpc GetDebugInfo (GetDebugInfoRequest) returns (GetDebugInfoResponse);
 
     /** lncli: `getrecoveryinfo`
     GetRecoveryInfo returns information concerning the recovery mode including
@@ -320,7 +329,7 @@ service Lightning {
     optionally specify the add_index and/or the settle_index. If the add_index
     is specified, then we'll first start by sending add invoice events for all
     invoices with an add_index greater than the specified value. If the
-    settle_index is specified, the next, we'll send out all settle events for
+    settle_index is specified, then next, we'll send out all settle events for
     invoices with a settle_index greater than the specified value. One or both
     of these fields can be set. If no fields are set, then we'll only send out
     the latest add/settle events.
@@ -339,13 +348,13 @@ service Lightning {
     */
     rpc ListPayments (ListPaymentsRequest) returns (ListPaymentsResponse);
 
-    /*
+    /* lncli: `deletepayments`
     DeletePayment deletes an outgoing payment from DB. Note that it will not
     attempt to delete an In-Flight payment, since that would be unsafe.
     */
     rpc DeletePayment (DeletePaymentRequest) returns (DeletePaymentResponse);
 
-    /*
+    /* lncli: `deletepayments --all`
     DeleteAllPayments deletes all outgoing payments from DB. Note that it will
     not attempt to delete In-Flight payments, since that would be unsafe.
     */
@@ -477,7 +486,7 @@ service Lightning {
     rpc ExportAllChannelBackups (ChanBackupExportRequest)
         returns (ChanBackupSnapshot);
 
-    /*
+    /* lncli: `verifychanbackup`
     VerifyChanBackup allows a caller to verify the integrity of a channel backup
     snapshot. This method will accept either a packed Single or a packed Multi.
     Specifying both will result in an error.
@@ -567,6 +576,10 @@ service Lightning {
     /* lncli: `subscribecustom`
     SubscribeCustomMessages subscribes to a stream of incoming custom peer
     messages.
+
+    To include messages with type outside of the custom range (>= 32768) lnd
+    needs to be compiled with  the `dev` build tag, and the message type to
+    override should be specified in lnd's experimental protocol configuration.
     */
     rpc SubscribeCustomMessages (SubscribeCustomMessagesRequest)
         returns (stream CustomMessage);
@@ -577,6 +590,28 @@ service Lightning {
     zero conf).
     */
     rpc ListAliases (ListAliasesRequest) returns (ListAliasesResponse);
+
+    /*
+    LookupHtlcResolution retrieves a final htlc resolution from the database.
+    If the htlc has no final resolution yet, a NotFound grpc status code is
+    returned.
+    */
+    rpc LookupHtlcResolution (LookupHtlcResolutionRequest)
+        returns (LookupHtlcResolutionResponse);
+}
+
+message LookupHtlcResolutionRequest {
+    uint64 chan_id = 1;
+
+    uint64 htlc_index = 2;
+}
+
+message LookupHtlcResolutionResponse {
+    // Settled is true is the htlc was settled. If false, the htlc was failed.
+    bool settled = 1;
+
+    // Offchain indicates whether the htlc was resolved off-chain or on-chain.
+    bool offchain = 2;
 }
 
 message SubscribeCustomMessagesRequest {
@@ -598,6 +633,9 @@ message SendCustomMessageRequest {
     bytes peer = 1;
 
     // Message type. This value needs to be in the custom range (>= 32768).
+    // To send a type < custom range, lnd needs to be compiled with the `dev`
+    // build tag, and the message type to override should be specified in lnd's
+    // experimental protocol configuration.
     uint32 type = 2;
 
     // Raw message data.
@@ -637,6 +675,7 @@ enum OutputScriptType {
     SCRIPT_TYPE_NULLDATA = 6;
     SCRIPT_TYPE_NON_STANDARD = 7;
     SCRIPT_TYPE_WITNESS_UNKNOWN = 8;
+    SCRIPT_TYPE_WITNESS_V1_TAPROOT = 9;
 }
 
 message OutputDetail {
@@ -1320,6 +1359,13 @@ enum CommitmentType {
     channel before its maturity date.
     */
     SCRIPT_ENFORCED_LEASE = 4;
+
+    /*
+    A channel that uses musig2 for the funding output, and the new tapscript
+    features where relevant.
+    */
+    // TODO(roasbeef): need script enforce mirror type for the above as well?
+    SIMPLE_TAPROOT = 5;
 }
 
 message ChannelConstraints {
@@ -1509,6 +1555,19 @@ message Channel {
 
     // This is the confirmed / on-chain zero-conf SCID.
     uint64 zero_conf_confirmed_scid = 33;
+
+    // The configured alias name of our peer.
+    string peer_alias = 34;
+
+    // This is the peer SCID alias.
+    uint64 peer_scid_alias = 35 [jstype = JS_STRING];
+
+    /*
+    An optional note-to-self to go along with the channel containing some
+    useful information. This is only ever stored locally and in no way impacts
+    the channel's operation.
+    */
+    string memo = 36;
 }
 
 message ListChannelsRequest {
@@ -1522,6 +1581,11 @@ message ListChannelsRequest {
     empty, all channels will be returned.
     */
     bytes peer = 5;
+
+    // Informs the server if the peer alias lookup per channel should be
+    // enabled. It is turned off by default in order to avoid degradation of
+    // performance for existing clients.
+    bool peer_alias_lookup = 6;
 }
 message ListChannelsResponse {
     // The list of active channels
@@ -1869,13 +1933,16 @@ message GetInfoResponse {
     /*
     Whether the current node is connected to testnet. This field is
     deprecated and the network field should be used instead
-    **/
+    */
     bool testnet = 10 [deprecated = true];
 
     reserved 11;
 
-    // A list of active chains the node is connected to
-    repeated Chain chains = 16;
+    /*
+    Deprecated. The only active chain is bitcoin.
+    A list of active chains the node is connected to
+    */
+    repeated Chain chains = 16 [deprecated = true];
 
     // The URIs of the current node.
     repeated string uris = 12;
@@ -1890,6 +1957,17 @@ message GetInfoResponse {
     Indicates whether the HTLC interceptor API is in always-on mode.
     */
     bool require_htlc_interceptor = 21;
+
+    // Indicates whether final htlc resolutions are stored on disk.
+    bool store_final_htlc_resolutions = 22;
+}
+
+message GetDebugInfoRequest {
+}
+
+message GetDebugInfoResponse {
+    map<string, string> config = 1;
+    repeated string log = 2;
 }
 
 message GetRecoveryInfoRequest {
@@ -1906,8 +1984,9 @@ message GetRecoveryInfoResponse {
 }
 
 message Chain {
-    // The blockchain the node is on (eg bitcoin, litecoin)
-    string chain = 1;
+    // Deprecated. The chain is now always assumed to be bitcoin.
+    // The blockchain the node is on (must be bitcoin)
+    string chain = 1 [deprecated = true];
 
     // The network the node is on (eg regtest, testnet, mainnet)
     string network = 2;
@@ -2075,6 +2154,76 @@ message BatchOpenChannel {
     the remote peer supports explicit channel negotiation.
     */
     CommitmentType commitment_type = 9;
+
+    /*
+    The maximum amount of coins in millisatoshi that can be pending within
+    the channel. It only applies to the remote party.
+    */
+    uint64 remote_max_value_in_flight_msat = 10;
+
+    /*
+    The maximum number of concurrent HTLCs we will allow the remote party to add
+    to the commitment transaction.
+    */
+    uint32 remote_max_htlcs = 11;
+
+    /*
+    Max local csv is the maximum csv delay we will allow for our own commitment
+    transaction.
+    */
+    uint32 max_local_csv = 12;
+
+    /*
+    If this is true, then a zero-conf channel open will be attempted.
+    */
+    bool zero_conf = 13;
+
+    /*
+    If this is true, then an option-scid-alias channel-type open will be
+    attempted.
+    */
+    bool scid_alias = 14;
+
+    /*
+    The base fee charged regardless of the number of milli-satoshis sent.
+    */
+    uint64 base_fee = 15;
+
+    /*
+    The fee rate in ppm (parts per million) that will be charged in
+    proportion of the value of each forwarded HTLC.
+    */
+    uint64 fee_rate = 16;
+
+    /*
+    If use_base_fee is true the open channel announcement will update the
+    channel base fee with the value specified in base_fee. In the case of
+    a base_fee of 0 use_base_fee is needed downstream to distinguish whether
+    to use the default base fee value specified in the config or 0.
+    */
+    bool use_base_fee = 17;
+
+    /*
+    If use_fee_rate is true the open channel announcement will update the
+    channel fee rate with the value specified in fee_rate. In the case of
+    a fee_rate of 0 use_fee_rate is needed downstream to distinguish whether
+    to use the default fee rate value specified in the config or 0.
+    */
+    bool use_fee_rate = 18;
+
+    /*
+    The number of satoshis we require the remote peer to reserve. This value,
+    if specified, must be above the dust limit and below 20% of the channel
+    capacity.
+    */
+    uint64 remote_chan_reserve_sat = 19;
+
+    /*
+    An optional note-to-self to go along with the channel containing some
+    useful information. This is only ever stored locally and in no way impacts
+    the channel's operation.
+    */
+    string memo = 20;
 }
 
 message BatchOpenChannelResponse {
@@ -2189,6 +2338,59 @@ message OpenChannelRequest {
     attempted.
     */
     bool scid_alias = 20;
+
+    /*
+    The base fee charged regardless of the number of milli-satoshis sent.
+    */
+    uint64 base_fee = 21;
+
+    /*
+    The fee rate in ppm (parts per million) that will be charged in
+    proportion of the value of each forwarded HTLC.
+    */
+    uint64 fee_rate = 22;
+
+    /*
+    If use_base_fee is true the open channel announcement will update the
+    channel base fee with the value specified in base_fee. In the case of
+    a base_fee of 0 use_base_fee is needed downstream to distinguish whether
+    to use the default base fee value specified in the config or 0.
+    */
+    bool use_base_fee = 23;
+
+    /*
+    If use_fee_rate is true the open channel announcement will update the
+    channel fee rate with the value specified in fee_rate. In the case of
+    a fee_rate of 0 use_fee_rate is needed downstream to distinguish whether
+    to use the default fee rate value specified in the config or 0.
+    */
+    bool use_fee_rate = 24;
+
+    /*
+    The number of satoshis we require the remote peer to reserve. This value,
+    if specified, must be above the dust limit and below 20% of the channel
+    capacity.
+    */
+    uint64 remote_chan_reserve_sat = 25;
+
+    /*
+    If set, then lnd will attempt to commit all the coins under control of the
+    internal wallet to open the channel, and the LocalFundingAmount field must
+    be zero and is ignored.
+    */
+    bool fund_max = 26;
+
+    /*
+    An optional note-to-self to go along with the channel containing some
+    useful information. This is only ever stored locally and in no way impacts
+    the channel's operation.
+    */
+    string memo = 27;
+
+    /*
+    A list of selected outpoints that are allocated for channel funding.
+    */
+    repeated OutPoint outpoints = 28;
 }
 message OpenStatusUpdate {
     oneof update {
@@ -2270,6 +2472,11 @@ message ChanPointShim {
     the value is less than 500,000, or as an absolute height otherwise.
     */
     uint32 thaw_height = 6;
+
+    /*
+    Indicates that the funding output is using a MuSig2 multi-sig output.
+    */
+    bool musig2 = 7;
 }
 
 message PsbtShim {
@@ -2455,6 +2662,13 @@ message PendingChannelsResponse {
 
         // Whether this channel is advertised to the network or not.
         bool private = 12;
+
+        /*
+        An optional note-to-self to go along with the channel containing some
+        useful information. This is only ever stored locally and in no way
+        impacts the channel's operation.
+        */
+        string memo = 13;
     }
 
     message PendingOpenChannel {
@@ -2482,6 +2696,17 @@ message PendingChannelsResponse {
 
         // Previously used for confirmation_height. Do not reuse.
         reserved 2;
+
+        // The number of blocks until the funding transaction is considered
+        // expired. If this value gets close to zero, there is a risk that the
+        // channel funding will be canceled by the channel responder. The
+        // channel should be fee bumped using CPFP (see walletrpc.BumpFee) to
+        // ensure that the channel confirms in time. Otherwise a force-close
+        // will be necessary if the channel confirms after the funding
+        // transaction expires. A negative value means the channel responder has
+        // very likely canceled the funding and the channel will never become
+        // fully operational.
+        int32 funding_expiry_blocks = 3;
     }
 
     message WaitingCloseChannel {
@@ -2563,9 +2788,17 @@ message PendingChannelsResponse {
 
         repeated PendingHTLC pending_htlcs = 8;
 
+        /*
+          There are three resolution states for the anchor:
+          limbo, lost and recovered. Derive the current state
+          from the limbo and recovered balances.
+        */
         enum AnchorState {
+            // The recovered_balance is zero and limbo_balance is non-zero.
             LIMBO = 0;
+            // The recovered_balance is non-zero.
             RECOVERED = 1;
+            // A state that is neither LIMBO nor RECOVERED.
             LOST = 2;
         }
 
@@ -2626,6 +2859,14 @@ message WalletAccountBalance {
 }
 
 message WalletBalanceRequest {
+    // The wallet account the balance is shown for.
+    // If this is not specified, the balance of the "default" account is shown.
+    string account = 1;
+
+    // The minimum number of confirmations each one of your outputs used for the
+    // funding transaction must satisfy. If this is not specified, the default
+    // value of 1 is used.
+    int32 min_confs = 2;
 }
 
 message WalletBalanceResponse {
@@ -2711,6 +2952,9 @@ message QueryRoutesRequest {
     not add any additional block padding on top of final_ctlv_delta. This
     padding of a few blocks needs to be added manually or otherwise failures may
     happen when a block comes in while the payment is in flight.
+
+    Note: must not be set if making a payment to a blinded path (delta is
+    set by the aggregate parameters provided by blinded_payment_paths)
     */
     int32 final_cltv_delta = 4;
 
@@ -2785,11 +3029,20 @@ message QueryRoutesRequest {
     repeated lnrpc.RouteHint route_hints = 16;
 
     /*
+    An optional blinded path(s) to reach the destination. Note that the
+    introduction node must be provided as the first hop in the route.
+    */
+    repeated BlindedPaymentPath blinded_payment_paths = 19;
+
+    /*
     Features assumed to be supported by the final node. All transitive feature
     dependencies must also be set properly. For a given feature bit pair, either
     optional or remote may be set, but not both. If this field is nil or empty,
     the router will try to load destination features from the graph as a
     fallback.
+
+    Note: must not be set if making a payment to a blinded route (features
+    are provided in blinded_payment_paths).
     */
     repeated lnrpc.FeatureBit dest_features = 17;
 
@@ -2895,6 +3148,32 @@ message Hop {
 
     // The payment metadata to send along with the payment to the payee.
     bytes metadata = 13;
+
+    /*
+    Blinding point is an optional blinding point included for introduction
+    nodes in blinded paths. This field is mandatory for hops that represents
+    the introduction point in a blinded path.
+    */
+    bytes blinding_point = 14;
+
+    /*
+    Encrypted data is a receiver-produced blob of data that provides hops
+    in a blinded route with forwarding data. As this data is encrypted by
+    the recipient, we will not be able to parse it - it is essentially an
+    arbitrary blob of data from our node's perspective. This field is
+    mandatory for all hops in a blinded path, including the introduction
+    node.
+    */
+    bytes encrypted_data = 15;
+
+    /*
+    The total amount that is sent to the recipient (possibly across multiple
+    HTLCs), as specified by the sender when making a payment to a blinded path.
+    This value is only set in the final hop payload of a blinded payment. This
+    value is analogous to the MPPRecord that is used for regular (non-blinded)
+    MPP payments.
+    */
+    uint64 total_amt_msat = 16;
 }
 
 message MPPRecord {
@@ -3011,6 +3290,9 @@ message LightningNode {
     repeated NodeAddress addresses = 4;
     string color = 5;
     map<uint32, Feature> features = 6;
+
+    // Custom node announcement tlv records.
+    map<uint64, bytes> custom_records = 7;
 }
 
 message NodeAddress {
@@ -3026,6 +3308,9 @@ message RoutingPolicy {
     bool disabled = 5;
     uint64 max_htlc_msat = 6;
     uint32 last_update = 7;
+
+    // Custom channel update tlv records.
+    map<uint64, bytes> custom_records = 8;
 }
 
 /*
@@ -3053,6 +3338,9 @@ message ChannelEdge {
 
     RoutingPolicy node1_policy = 7;
     RoutingPolicy node2_policy = 8;
+
+    // Custom channel announcement tlv records.
+    map<uint64, bytes> custom_records = 9;
 }
 
 message ChannelGraphRequest {
@@ -3231,6 +3519,61 @@ message RouteHint {
     repeated HopHint hop_hints = 1;
 }
 
+message BlindedPaymentPath {
+    // The blinded path to send the payment to.
+    BlindedPath blinded_path = 1;
+
+    // The base fee for the blinded path provided, expressed in msat.
+    uint64 base_fee_msat = 2;
+
+    // The proportional fee for the blinded path provided, expressed in msat.
+    uint64 proportional_fee_msat = 3;
+
+    /*
+    The total CLTV delta for the blinded path provided, including the
+    final CLTV delta for the receiving node.
+    */
+    uint32 total_cltv_delta = 4;
+
+    /*
+    The minimum hltc size that may be sent over the blinded path, expressed
+    in msat.
+    */
+    uint64 htlc_min_msat = 5;
+
+    /*
+    The maximum htlc size that may be sent over the blinded path, expressed
+    in msat.
+    */
+    uint64 htlc_max_msat = 6;
+
+    // The feature bits for the route.
+    repeated FeatureBit features = 7;
+}
+
+message BlindedPath {
+    // The unblinded pubkey of the introduction node for the route.
+    bytes introduction_node = 1;
+
+    // The ephemeral pubkey used by nodes in the blinded route.
+    bytes blinding_point = 2;
+
+    /*
+    A set of blinded node keys and data blobs for the blinded portion of the
+    route. Note that the first hop is expected to be the introduction node,
+    so the route is always expected to have at least one hop.
+    */
+    repeated BlindedHop blinded_hops = 3;
+}
+
+message BlindedHop {
+    // The blinded public key of the node.
+    bytes blinded_node = 1;
+
+    // An encrypted blob of data provided to the blinded node.
+    bytes encrypted_data = 2;
+}
+
 message AMPInvoiceState {
     // The state the HTLCs associated with this setID are in.
     InvoiceHTLCState state = 1;
@@ -3285,7 +3628,7 @@ message Invoice {
     int64 value_msat = 23;
 
     /*
-    Whether this invoice has been fulfilled
+    Whether this invoice has been fulfilled.
 
     The field is deprecated. Use the state field instead (compare to SETTLED).
     */
@@ -3293,12 +3636,14 @@ message Invoice {
 
     /*
     When this invoice was created.
+    Measured in seconds since the unix epoch.
     Note: Output only, don't specify for creating an invoice.
     */
     int64 creation_date = 7;
 
     /*
     When this invoice was settled.
+    Measured in seconds since the unix epoch.
     Note: Output only, don't specify for creating an invoice.
     */
     int64 settle_date = 8;
@@ -3319,7 +3664,7 @@ message Invoice {
     */
     bytes description_hash = 10;
 
-    // Payment request expiry time in seconds. Default is 3600 (1 hour).
+    // Payment request expiry time in seconds. Default is 86400 (24 hours).
     int64 expiry = 11;
 
     // Fallback on-chain address.
@@ -3335,6 +3680,8 @@ message Invoice {
     repeated RouteHint route_hints = 14;
 
     // Whether this invoice should include routing hints for private channels.
+    // Note: When enabled, if value and value_msat are zero, a large number of
+    // hints with these channels can be included, which might not be desirable.
     bool private = 15;
 
     /*
@@ -3360,22 +3707,22 @@ message Invoice {
 
     /*
     The amount that was accepted for this invoice, in satoshis. This will ONLY
-    be set if this invoice has been settled. We provide this field as if the
-    invoice was created with a zero value, then we need to record what amount
-    was ultimately accepted. Additionally, it's possible that the sender paid
-    MORE that was specified in the original invoice. So we'll record that here
-    as well.
+    be set if this invoice has been settled or accepted. We provide this field
+    as if the invoice was created with a zero value, then we need to record what
+    amount was ultimately accepted. Additionally, it's possible that the sender
+    paid MORE that was specified in the original invoice. So we'll record that
+    here as well.
     Note: Output only, don't specify for creating an invoice.
     */
     int64 amt_paid_sat = 19;
 
     /*
     The amount that was accepted for this invoice, in millisatoshis. This will
-    ONLY be set if this invoice has been settled. We provide this field as if
-    the invoice was created with a zero value, then we need to record what
-    amount was ultimately accepted. Additionally, it's possible that the sender
-    paid MORE that was specified in the original invoice. So we'll record that
-    here as well.
+    ONLY be set if this invoice has been settled or accepted. We provide this
+    field as if the invoice was created with a zero value, then we need to
+    record what amount was ultimately accepted. Additionally, it's possible that
+    the sender paid MORE that was specified in the original invoice. So we'll
+    record that here as well.
     Note: Output only, don't specify for creating an invoice.
     */
     int64 amt_paid_msat = 20;
@@ -3563,7 +3910,16 @@ message ListInvoiceRequest {
     specified index offset. This can be used to paginate backwards.
     */
     bool reversed = 6;
+
+    // If set, returns all invoices with a creation date greater than or equal
+    // to it. Measured in seconds since the unix epoch.
+    uint64 creation_date_start = 7;
+
+    // If set, returns all invoices with a creation date less than or equal to
+    // it. Measured in seconds since the unix epoch.
+    uint64 creation_date_end = 8;
 }
+
 message ListInvoiceResponse {
     /*
     A list of invoices from the time slice of the time series specified in the
@@ -3664,10 +4020,20 @@ message Payment {
     string payment_request = 9;
 
     enum PaymentStatus {
-        UNKNOWN = 0;
+        // Deprecated. This status will never be returned.
+        UNKNOWN = 0 [deprecated = true];
+
+        // Payment has inflight HTLCs.
         IN_FLIGHT = 1;
+
+        // Payment is settled.
         SUCCEEDED = 2;
+
+        // Payment is failed.
         FAILED = 3;
+
+        // Payment is created and has not attempted any HTLCs.
+        INITIATED = 4;
     }
 
     // The status of the payment.
@@ -3762,6 +4128,14 @@ message ListPaymentsRequest {
     of payments, as all of them have to be iterated through to be counted.
     */
     bool count_total_payments = 5;
+
+    // If set, returns all invoices with a creation date greater than or equal
+    // to it. Measured in seconds since the unix epoch.
+    uint64 creation_date_start = 6;
+
+    // If set, returns all invoices with a creation date less than or equal to
+    // it. Measured in seconds since the unix epoch.
+    uint64 creation_date_end = 7;
 }
 
 message ListPaymentsResponse {
@@ -4006,6 +4380,10 @@ message ForwardingHistoryRequest {
 
     // The max number of events to return in the response to this query.
     uint32 num_max_events = 4;
+
+    // Informs the server if the peer alias should be looked up for each
+    // forwarding event.
+    bool peer_alias_lookup = 5;
 }
 message ForwardingEvent {
     // Timestamp is the time (unix epoch offset) that this circuit was
@@ -4044,6 +4422,12 @@ message ForwardingEvent {
     // The number of nanoseconds elapsed since January 1, 1970 UTC when this
     // circuit was completed.
     uint64 timestamp_ns = 11;
+
+    // The peer alias of the incoming channel.
+    string peer_alias_in = 12;
+
+    // The peer alias of the outgoing channel.
+    string peer_alias_out = 13;
 
     // TODO(roasbeef): add settlement latency?
     //  * use FPE on the chan id?
@@ -4229,6 +4613,7 @@ message Failure {
         EXPIRY_TOO_FAR = 22;
         MPP_TIMEOUT = 23;
         INVALID_ONION_PAYLOAD = 24;
+        INVALID_ONION_BLINDING = 25;
 
         /*
         An internal error occurred.

--- a/vendor/signrpc/signer.proto
+++ b/vendor/signrpc/signer.proto
@@ -349,6 +349,12 @@ message SignMessageReq {
     privKey + h_tapTweak(internalKey || tapTweak)
     */
     bytes schnorr_sig_tap_tweak = 6;
+
+    /*
+    An optional tag that can be provided when taking a tagged hash of a
+    message. This option can only be used when schnorr_sig is true.
+    */
+    bytes tag = 7;
 }
 message SignMessageResp {
     /*
@@ -385,6 +391,13 @@ message VerifyMessageReq {
 message VerifyMessageResp {
     // Whether the signature was valid over the given message.
     bool valid = 1;
+
+    
+    /*
+    An optional tag that can be provided when taking a tagged hash of a
+    message. This option can only be used when is_schnorr_sig is true.
+    */
+    bytes tag = 5;
 }
 
 message SharedKeyRequest {
@@ -444,12 +457,33 @@ message TaprootTweakDesc {
     bool key_spend_only = 2;
 }
 
+enum MuSig2Version {
+    /*
+    The default value on the RPC is zero for enums so we need to represent an
+    invalid/undefined version by default to make sure clients upgrade their
+    software to set the version explicitly.
+    */
+    MUSIG2_VERSION_UNDEFINED = 0;
+
+    /*
+    The version of MuSig2 that lnd 0.15.x shipped with, which corresponds to the
+    version v0.4.0 of the MuSig2 BIP draft.
+    */
+    MUSIG2_VERSION_V040 = 1;
+
+    /*
+    The current version of MuSig2 which corresponds to the version v1.0.0rc2 of
+    the MuSig2 BIP draft.
+    */
+    MUSIG2_VERSION_V100RC2 = 2;
+}
+
 message MuSig2CombineKeysRequest {
     /*
-    A list of all public keys (serialized in 32-byte x-only format!)
-    participating in the signing session. The list will always be sorted
-    lexicographically internally. This must include the local key which is
-    described by the above key_loc.
+    A list of all public keys (serialized in 32-byte x-only format for v0.4.0
+    and 33-byte compressed format for v1.0.0rc2!) participating in the signing
+    session. The list will always be sorted lexicographically internally. This
+    must include the local key which is described by the above key_loc.
     */
     repeated bytes all_signer_pubkeys = 1;
 
@@ -465,6 +499,14 @@ message MuSig2CombineKeysRequest {
     on-chain.
     */
     TaprootTweakDesc taproot_tweak = 3;
+
+    /*
+    The mandatory version of the MuSig2 BIP draft to use. This is necessary to
+    differentiate between the changes that were made to the BIP while this
+    experimental RPC was already released. Some of those changes affect how the
+    combined key and nonces are created.
+    */
+    MuSig2Version version = 4;
 }
 
 message MuSig2CombineKeysResponse {
@@ -482,6 +524,11 @@ message MuSig2CombineKeysResponse {
     is used.
     */
     bytes taproot_internal_key = 2;
+
+    /*
+    The version of the MuSig2 BIP that was used to combine the keys.
+    */
+    MuSig2Version version = 4;
 }
 
 message MuSig2SessionRequest {
@@ -491,10 +538,10 @@ message MuSig2SessionRequest {
     KeyLocator key_loc = 1;
 
     /*
-    A list of all public keys (serialized in 32-byte x-only format!)
-    participating in the signing session. The list will always be sorted
-    lexicographically internally. This must include the local key which is
-    described by the above key_loc.
+    A list of all public keys (serialized in 32-byte x-only format for v0.4.0
+    and 33-byte compressed format for v1.0.0rc2!) participating in the signing
+    session. The list will always be sorted lexicographically internally. This
+    must include the local key which is described by the above key_loc.
     */
     repeated bytes all_signer_pubkeys = 2;
 
@@ -516,6 +563,24 @@ message MuSig2SessionRequest {
     on-chain.
     */
     TaprootTweakDesc taproot_tweak = 5;
+
+    /*
+    The mandatory version of the MuSig2 BIP draft to use. This is necessary to
+    differentiate between the changes that were made to the BIP while this
+    experimental RPC was already released. Some of those changes affect how the
+    combined key and nonces are created.
+    */
+    MuSig2Version version = 6;
+
+    /*
+    A set of pre generated secret local nonces to use in the musig2 session.
+    This field is optional. This can be useful for protocols that need to send
+    nonces ahead of time before the set of signer keys are known. This value
+    MUST be 97 bytes and be the concatenation of two CSPRNG generated 32 byte
+    values and local public key used for signing as specified in the key_loc
+    field.
+    */
+    bytes pregenerated_local_nonce = 7;
 }
 
 message MuSig2SessionResponse {
@@ -553,6 +618,11 @@ message MuSig2SessionResponse {
     now.
     */
     bool have_all_nonces = 5;
+
+    /*
+    The version of the MuSig2 BIP that was used to create the session.
+    */
+    MuSig2Version version = 6;
 }
 
 message MuSig2RegisterNoncesRequest {


### PR DESCRIPTION
This PR compiles a few tonic_lnd changes we need for LNDK:
- Allows the option to load the LND tls cert and macaroon from memory.
- We also update the signer and lightning protos because we need two LND updates for LNDK:
    - The tagged_hash option for signing a message.
    - The blinded route option in QueryRoutes/SendToRoute.

We're not pushing these changes upstream yet (and just using our own branch) because they won't officially be options until v0.18.0.
